### PR TITLE
Bump version to 3.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            2.x
 
   release:
     runs-on: ubuntu-latest

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ group = com.enonic.app
 projectName = tinyblog
 appName = com.enonic.app.tinyblog
 xpVersion = 8.0.0-B4
-version=2.0.2-SNAPSHOT
+version=3.0.0-SNAPSHOT


### PR DESCRIPTION
## Summary

- Bumps `version` in `gradle.properties` from `2.0.2-SNAPSHOT` to `3.0.0-SNAPSHOT` for the XP 8 line on master
- Adds a `releaseBranch:` block to `.github/workflows/enonic-gradle.yml` listing both `master` and the new `2.x` maintenance branch, so the release tooling recognizes pushes on either branch as release-branch builds
- Companion to a separate PR on `2.x` that adds the same `releaseBranch:` block to the workflow file on that branch (the action reads `releaseBranch:` from the branch's own workflow)

The `2.x` maintenance branch was created from `9a7805e` ("Updated to next SNAPSHOT version"), the first post-`v2.0.1` commit on master where `gradle.properties` is back to `2.0.2-SNAPSHOT`.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, `./gradlew clean build` from master is green