### PR TITLE
Add release-branch CI config for 2.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ${{ secrets.ARTIFACTORY_USERNAME }}
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            2.x
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Adds a `releaseBranch:` block to `.github/workflows/enonic-gradle.yml` listing both `master` and `2.x`, so pushes on `2.x` are classified as release-branch builds by the Enonic release tooling
- The release action reads `releaseBranch:` from the branch's own workflow file, so this companion change on `2.x` is required in addition to the matching edit on master (#34)

No version bump or other changes here — `2.x` stays on `2.0.2-SNAPSHOT` / XP 7.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, a CI run on `2.x` is classified as a release-branch build