### PR TITLE
Migrate to lib-asset #37

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ dependencies {
     include xplibs.content
     include xplibs.portal
     include "com.enonic.lib:lib-thymeleaf:3.0.0-SNAPSHOT"
+    include "com.enonic.lib:lib-asset:2.0.0-SNAPSHOT"
 }
 
 repositories {

--- a/src/main/resources/cms/parts/blog-overview/blog-overview.js
+++ b/src/main/resources/cms/parts/blog-overview/blog-overview.js
@@ -1,4 +1,5 @@
 var portal = require('/lib/xp/portal'); // Import the portal library
+var assetLib = require('/lib/enonic/asset'); // Import the asset library
 var thymeleaf = require('/lib/thymeleaf'); // Import the Thymeleaf library
 var contentLib = require('/lib/xp/content');
 
@@ -97,7 +98,7 @@ function formatDate(dateString, seperator) {
 // Handle the GET request
 exports.get = function (req) {
 
-    var css = portal.assetUrl({ path: "style.css" });
+    var css = assetLib.assetUrl({ path: "style.css" });
 
     var model = createModel();
     var view = resolve('blog-overview.html');

--- a/src/main/resources/cms/parts/blog-show/blog-show.js
+++ b/src/main/resources/cms/parts/blog-show/blog-show.js
@@ -1,4 +1,5 @@
 var portal = require('/lib/xp/portal');
+var assetLib = require('/lib/enonic/asset');
 var thymeleaf = require('/lib/thymeleaf');
 var contentLib = require('/lib/xp/content');
 
@@ -33,7 +34,7 @@ exports.get = function (req) {
 
     //What html document to use
     var view = resolve('blog-show.html');
-    var css = portal.assetUrl({ path: "style.css" });
+    var css = assetLib.assetUrl({ path: "style.css" });
 
     // Return the merged view and model in the response object
     return {

--- a/src/main/resources/cms/site.yaml
+++ b/src/main/resources/cms/site.yaml
@@ -1,1 +1,3 @@
 kind: "Site"
+apis:
+  - "asset"


### PR DESCRIPTION
Closes #37.

`portal.assetUrl` is `@deprecated` in lib-portal — migrating to lib-asset, which fits this app's site context.

## What changed

- `build.gradle` — added `include "com.enonic.lib:lib-asset:2.0.0-SNAPSHOT"`.
- `src/main/resources/cms/site.yaml` — registered `apis: ["asset"]` so the lib-asset Universal API is mounted in site context.
- `src/main/resources/cms/parts/blog-show/blog-show.js` — `portal.assetUrl({path: "style.css"})` → `assetLib.assetUrl({path: "style.css"})`.
- `src/main/resources/cms/parts/blog-overview/blog-overview.js` — same swap.

`/lib/xp/portal` import stays — both files still use `portal.imageUrl`, `portal.getContent`, etc.

## Test plan

- [x] `./gradlew build --refresh-dependencies` clean.
- [x] Deployed against XP `8.0.0-B4` in `/tmp/xp-e2e-*`; bundle reaches ACTIVE.
- [x] After bootstrapping `com.enonic.cms.default` + `default` project + an `e2e` site with `applicationKey: com.enonic.app.tinyblog`, `assetLib.assetUrl({path: 'style.css'})` invoked from a service inside the tinyblog bundle (in site context) returned `/site/default/master/e2e/_/com.enonic.app.tinyblog:asset/0000004a16dd9400/style.css`.
- [x] That generated URL serves `assets/style.css` (HTTP 200, `Content-Type: text/css`, bytes identical to the source `assets/style.css`).