### PR TITLE
Introduce TOML version catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,8 +9,8 @@ dependencies {
     implementation xplibs.api.portal
     include xplibs.content
     include xplibs.portal
-    include "com.enonic.lib:lib-thymeleaf:3.0.0-SNAPSHOT"
-    include "com.enonic.lib:lib-asset:2.0.0-SNAPSHOT"
+    include libs.lib.thymeleaf
+    include libs.lib.asset
 }
 
 repositories {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,7 @@
+[versions]
+asset = "2.0.0-SNAPSHOT"
+thymeleaf = "3.0.0-SNAPSHOT"
+
+[libraries]
+lib-asset = { module = "com.enonic.lib:lib-asset", version.ref = "asset" }
+lib-thymeleaf = { module = "com.enonic.lib:lib-thymeleaf", version.ref = "thymeleaf" }


### PR DESCRIPTION
## Summary

Move the two inline-versioned dependencies (`lib-thymeleaf`, `lib-asset`) into a new `gradle/libs.versions.toml`. `xplibs.*` accessors and the `xpVersion` property in `gradle.properties` stay where they are.

Conventions adopted (matching the dominant style in neighbouring catalogs across the IdeaProjects tree, e.g. `app-disqus`, `app-rss`, `app-siteimprove`):

- alphabetical sort in both `[versions]` and `[libraries]`
- lowercase, hyphen-separated keys
- `xpVersion` left in `gradle.properties` (the rest of the toolchain expects it there)

Pin-for-pin migration — no version bumps. The resolved `runtimeClasspath` tree is unchanged.

## New catalog

```toml
[versions]
asset = "2.0.0-SNAPSHOT"
thymeleaf = "3.0.0-SNAPSHOT"

[libraries]
lib-asset = { module = "com.enonic.lib:lib-asset", version.ref = "asset" }
lib-thymeleaf = { module = "com.enonic.lib:lib-thymeleaf", version.ref = "thymeleaf" }
```

## Test plan

- [x] `./gradlew build --refresh-dependencies` — green locally
- [x] `./gradlew dependencies --configuration runtimeClasspath` — identical to pre-migration tree

<sub>*Drafted with AI assistance*</sub>